### PR TITLE
Ability to work with Tag classes without registering them to oval

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-module.exports = {
+var isFunction = require('./lib/utils/isFunction')
+var ovalInstance = {
   registeredTags: [],
   init: function (plasma) {
     this.plasma = require('./lib/organic-plasma-dom')(plasma)
@@ -36,14 +37,26 @@ module.exports = {
     return tags
   },
   mountAt: function (el, tagName, props, attrs) {
-    var TagClass = this.getRegisteredTag(tagName)
+    var TagClass
+    if (isFunction(tagName)) {
+      TagClass = tagName
+      tagName = TagClass.tagName
+    } else {
+      TagClass = this.getRegisteredTag(tagName)
+    }
     if (!TagClass) throw new Error(tagName + ' not registered')
     var instance = new TagClass(el, props, attrs)
     instance.mount()
     return instance
   },
   appendAt: function (el, tagName, props, attrs) {
-    var TagClass = this.getRegisteredTag(tagName)
+    var TagClass
+    if (isFunction(tagName)) {
+      TagClass = tagName
+      tagName = TagClass.tagName
+    } else {
+      TagClass = this.getRegisteredTag(tagName)
+    }
     if (!TagClass) throw new Error(tagName + ' not registered')
     var newEl = document.createElement(tagName)
     el.appendChild(newEl)
@@ -60,3 +73,11 @@ module.exports = {
     return TagClass
   }
 }
+
+if (window.ovalInstance && window.globalOval) {
+  ovalInstance = window.ovalInstance
+} else {
+  ovalInstance.init()
+  window.ovalInstance = ovalInstance
+}
+module.exports = ovalInstance

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -4,7 +4,6 @@ var patch = require('incremental-dom').patch
 
 module.exports = function (oval) {
   return function (tag, rootEl, props, attrs) {
-    // // console.log('===== constructed =>', tag, rootEl)
     rootEl.tag = tag
     tag.root = rootEl
     tag.props = props || {}

--- a/lib/compilers/tag-file.js
+++ b/lib/compilers/tag-file.js
@@ -49,8 +49,7 @@ module.exports.compile = function (content) {
   var scriptContent = extractScript(lines)
   var tagInfo = extractTagInfo(lines)
   var htmlContent = lines.join('\n')
-  var result = `
-    class Tag {
+  var result = `class Tag {
       constructor (root, props, attrs) {
         var tag = this
         var tagAttrs = ${JSON.stringify(tagInfo.tagAttributes)}

--- a/lib/compilers/tag-file.js
+++ b/lib/compilers/tag-file.js
@@ -67,7 +67,11 @@ module.exports.compile = function (content) {
         }
       }
     }
-    oval.registerTag('${tagInfo.tagName}', Tag)
+    ${
+      tagInfo.tagFlags.indexOf('local-tag') === -1
+        ? `oval.registerTag('${tagInfo.tagName}', Tag)`
+        : ''
+    }
     Tag.tagName = "${tagInfo.tagName}"
     module.exports = Tag
   `

--- a/lib/compilers/tag-file.js
+++ b/lib/compilers/tag-file.js
@@ -49,22 +49,24 @@ module.exports.compile = function (content) {
   var scriptContent = extractScript(lines)
   var tagInfo = extractTagInfo(lines)
   var htmlContent = lines.join('\n')
-  var result = `class Tag {
-    constructor (root, props, attrs) {
-      var tag = this
-      var tagAttrs = ${JSON.stringify(tagInfo.tagAttributes)}
-      for (var key in tagAttrs) {
-        root.setAttribute(key, tagAttrs[key])
-      }
-      oval.BaseTag(tag, root, props, attrs)
-      ${scriptContent.trim()}
-      tag.render = function (createElement) {
-        return <virtual>${htmlContent}</virtual>
+  var result = `
+    class Tag {
+      constructor (root, props, attrs) {
+        var tag = this
+        var tagAttrs = ${JSON.stringify(tagInfo.tagAttributes)}
+        for (var key in tagAttrs) {
+          root.setAttribute(key, tagAttrs[key])
+        }
+        oval.BaseTag(tag, root, props, attrs)
+        ${scriptContent.trim()}
+        tag.render = function (createElement) {
+          return <virtual>${htmlContent}</virtual>
+        }
       }
     }
-  }
-  oval.registerTag('${tagInfo.tagName}', Tag)
-  export default Tag
-`
+    oval.registerTag('${tagInfo.tagName}', Tag)
+    Tag.tagName = "${tagInfo.tagName}"
+    module.exports = Tag
+  `
   return result
 }

--- a/lib/compilers/tag-file.js
+++ b/lib/compilers/tag-file.js
@@ -33,15 +33,19 @@ var extractTagInfo = function (lines) {
 
   var tagAttributes = {}
   //  class='login-view' asasd-asdd="asddd" assss="{ddddd}-1243&&@#jf. "
-  var parts = tagAttributesStr.trim().match(/(\S+)=["']?((?:.(?!["']?\s+(?:\S+)=|[>"']))+.)["']?/gm)
-  if (parts) {
-    for (var i = 0; i < parts.length; i += 1) {
-      var pairs = parts[i].split('=')
+  var attributesWithValue = tagAttributesStr.trim().match(/(\S+)=["']?((?:.(?!["']?\s+(?:\S+)=|[>"']))+.)["']?/gm)
+  if (attributesWithValue) {
+    for (var i = 0; i < attributesWithValue.length; i += 1) {
+      var pairs = attributesWithValue[i].split('=')
       tagAttributes[pairs[0]] = pairs[1].replace(/"/g, '').replace(/'/g, '')
     }
   }
 
-  return {tagName, tagAttributes}
+  // flag1 flag-two FLAG_THREE3
+  var tagFlags = tagAttributesStr.match(/ ([A-Za-z][0-9A-Za-z-_]*)(?![=[A-Za-z0-9-_])/g) || []
+  tagFlags = tagFlags.map((f) => f.trim()) // trim leading space because JS does not support lookbehind
+
+  return {tagName, tagAttributes, tagFlags}
 }
 
 module.exports.compile = function (content) {
@@ -69,3 +73,5 @@ module.exports.compile = function (content) {
   `
   return result
 }
+module.exports.extractTagInfo = extractTagInfo
+module.exports.extractScript = extractScript

--- a/lib/incremental-create-element.js
+++ b/lib/incremental-create-element.js
@@ -115,7 +115,7 @@ module.exports = function (tag, oval, directives) {
       var createdElement
       if (tagName !== 'virtual' || originalTagName) {
         // console.log('element open ->', tagName, parsedAttrs.key)
-        var TagClass = TagClass || oval.getRegisteredTag(originalTagName || tagName)
+        TagClass = TagClass || oval.getRegisteredTag(originalTagName || tagName)
         if (!TagClass) {
           IncrementalDOM.elementOpenStart(tagName, parsedAttrs.key, parsedAttrs.staticAttrs)
           for (var key in parsedAttrs.attrs) {

--- a/lib/incremental-create-element.js
+++ b/lib/incremental-create-element.js
@@ -1,4 +1,5 @@
 var IncrementalDOM = require('incremental-dom')
+var isFunction = require('./utils/isFunction')
 
 function parseAttrsObj (attrsObj) {
   var props = {}
@@ -45,8 +46,13 @@ function parseAttrsObj (attrsObj) {
 
 module.exports = function (tag, oval, directives) {
   var createElementWithDirectives = function (tagName, props, ...children) {
+    var TagClass
     var postCreateDirectives
     var originalTagName
+    if (isFunction(tagName)) {
+      TagClass = tagName
+      tagName = tagName.tagName
+    }
     if (props) {
       for (var p in directives) {
         if (typeof props[p] !== 'undefined') {
@@ -109,7 +115,7 @@ module.exports = function (tag, oval, directives) {
       var createdElement
       if (tagName !== 'virtual' || originalTagName) {
         // console.log('element open ->', tagName, parsedAttrs.key)
-        var TagClass = oval.getRegisteredTag(originalTagName || tagName)
+        var TagClass = TagClass || oval.getRegisteredTag(originalTagName || tagName)
         if (!TagClass) {
           IncrementalDOM.elementOpenStart(tagName, parsedAttrs.key, parsedAttrs.staticAttrs)
           for (var key in parsedAttrs.attrs) {

--- a/lib/utils/isFunction.js
+++ b/lib/utils/isFunction.js
@@ -1,3 +1,3 @@
-module.exports = function isFunction(functionToCheck) {
-  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
+module.exports = function isFunction (functionToCheck) {
+  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]'
 }

--- a/lib/utils/isFunction.js
+++ b/lib/utils/isFunction.js
@@ -1,0 +1,3 @@
+module.exports = function isFunction(functionToCheck) {
+  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
+}

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "chai": "^3.5.0",
     "eslint": "^3.1.1",
     "eslint-config-standard": "^5.3.5",
+    "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^2.0.0",
     "istanbul": "^0.4.4",
-    "jsdom": "^9.4.1",
-    "mocha": "^5.2.0",
-    "mocha-jsdom": "^1.1.0"
+    "jsdom": "^11.12.0",
+    "mocha": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "babel-cli": "^6.11.4",
     "babel-polyfill": "^6.9.1",
-    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.11.6",
     "chai": "^3.5.0",
     "eslint": "^3.1.1",
@@ -35,7 +35,7 @@
     "eslint-plugin-standard": "^2.0.0",
     "istanbul": "^0.4.4",
     "jsdom": "^9.4.1",
-    "mocha": "^2.5.3",
+    "mocha": "^5.2.0",
     "mocha-jsdom": "^1.1.0"
   }
 }

--- a/tests/compilers/extract-tag-info.test.js
+++ b/tests/compilers/extract-tag-info.test.js
@@ -1,0 +1,69 @@
+describe('oval-compiler - extractTagInfo', function () {
+  const {extractTagInfo, extractScript} = require('../../lib/compilers/tag-file')
+
+  it('name only', function () {
+    var content = `
+      <tag-name>
+        <script>
+          var constructorCode = true
+        </script>
+        <h1>html test</h1>
+      </tag-name>
+    `
+    var lines = content.trim().split('\n')
+    extractScript(lines)
+    var tagInfo = extractTagInfo(lines)
+    expect(tagInfo.tagName).to.eq('tag-name')
+    expect(tagInfo.tagAttributes).to.deep.eq({})
+  })
+
+  it('attrs', function () {
+    var content = `
+      <tag-name attr1="a" attr2="b">
+        <script>
+          var constructorCode = true
+        </script>
+        <h1>html test</h1>
+      </tag-name>
+    `
+    var lines = content.trim().split('\n')
+    extractScript(lines)
+    var tagInfo = extractTagInfo(lines)
+    expect(tagInfo.tagName).to.eq('tag-name')
+    expect(tagInfo.tagAttributes).to.deep.eq({attr1: 'a', attr2: 'b'})
+  })
+
+  it('flags', function () {
+    var content = `
+      <tag-name fl-ag1 fl2ag2 flag1 flag-two FLAG_THREE3>
+        <script>
+          var constructorCode = true
+        </script>
+        <h1>html test</h1>
+      </tag-name>
+    `
+    var lines = content.trim().split('\n')
+    extractScript(lines)
+    var tagInfo = extractTagInfo(lines)
+    expect(tagInfo.tagName).to.eq('tag-name')
+    expect(tagInfo.tagAttributes).to.deep.eq({})
+    expect(tagInfo.tagFlags).to.deep.eq(['fl-ag1', 'fl2ag2', 'flag1', 'flag-two', 'FLAG_THREE3'])
+  })
+
+  it('attrs and flags', function () {
+    var content = `
+      <tag-name attr1="a" flag_0 attr2="b" flag1 flag2>
+        <script>
+          var constructorCode = true
+        </script>
+        <h1>html test</h1>
+      </tag-name>
+    `
+    var lines = content.trim().split('\n')
+    extractScript(lines)
+    var tagInfo = extractTagInfo(lines)
+    expect(tagInfo.tagName).to.eq('tag-name')
+    expect(tagInfo.tagAttributes).to.deep.eq({attr1: 'a', attr2: 'b'})
+    expect(tagInfo.tagFlags).to.deep.eq(['flag_0', 'flag1', 'flag2'])
+  })
+})

--- a/tests/compilers/local-tag.test.js
+++ b/tests/compilers/local-tag.test.js
@@ -1,0 +1,73 @@
+describe('oval-compiler - flags - local-tag', function () {
+  /**
+   * If we have the local-tag flag to the component - we do not register is with oval.registerTag
+   */
+  var compiler = require('../../lib/compilers/tag-file')
+
+  it('without local-tag flag', function () {
+    var content = `
+      <tag-name>
+        <script>
+          var constructorCode = true
+        </script>
+        <h1>html test</h1>
+      </tag-name>
+    `
+
+    var expectedCompiledCode = `
+      class Tag {
+        constructor (root, props, attrs) {
+          var tag = this
+          var tagAttrs = {}
+          for (var key in tagAttrs) {
+            root.setAttribute(key, tagAttrs[key])
+          }
+          oval.BaseTag(tag, root, props, attrs)
+          var constructorCode = true
+          tag.render = function (createElement) {
+            return <virtual><h1>html test</h1></virtual>
+          }
+        }
+      }
+      oval.registerTag('tag-name', Tag)
+      Tag.tagName = "tag-name"
+      module.exports = Tag
+    `
+
+    var compiled = compiler.compile(content)
+    expect(compiled.trim().replace(/ /g, '').replace(/\n/g, '')).to.eq(expectedCompiledCode.trim().replace(/ /g, '').replace(/\n/g, ''))
+  })
+
+  it('without local-tag flag', function () {
+    var content = `
+      <tag-name local-tag>
+        <script>
+          var constructorCode = true
+        </script>
+        <h1>html test</h1>
+      </tag-name>
+    `
+
+    var expectedCompiledCode = `
+      class Tag {
+        constructor (root, props, attrs) {
+          var tag = this
+          var tagAttrs = {}
+          for (var key in tagAttrs) {
+            root.setAttribute(key, tagAttrs[key])
+          }
+          oval.BaseTag(tag, root, props, attrs)
+          var constructorCode = true
+          tag.render = function (createElement) {
+            return <virtual><h1>html test</h1></virtual>
+          }
+        }
+      }
+      Tag.tagName = "tag-name"
+      module.exports = Tag
+    `
+
+    var compiled = compiler.compile(content)
+    expect(compiled.trim().replace(/ /g, '').replace(/\n/g, '')).to.eq(expectedCompiledCode.trim().replace(/ /g, '').replace(/\n/g, ''))
+  })
+})

--- a/tests/compilers/tag-classes.test.js
+++ b/tests/compilers/tag-classes.test.js
@@ -6,6 +6,7 @@ describe('oval-compiler', function () {
       var constructorCode = true
     </script>
     <h1>html test</h1>
+    <CustomTagClass />
   </tag-name>
 `
 
@@ -19,7 +20,7 @@ describe('oval-compiler', function () {
       oval.BaseTag(tag, root, props, attrs)
       var constructorCode = true
       tag.render = function (createElement) {
-        return <virtual><h1>html test</h1></virtual>
+        return <virtual><h1>html test</h1><CustomTagClass /></virtual>
       }
     }
   }

--- a/tests/env.js
+++ b/tests/env.js
@@ -1,5 +1,8 @@
 module.exports = function () {
-  require('mocha-jsdom')()
+  var JSDOM = require('jsdom').JSDOM
+  const dom = new JSDOM('')
+  global.window = dom.window
+  global.document = dom.window.document
   before(function () {
     global.Element = window.Element
   })

--- a/tests/oval/index.test.js
+++ b/tests/oval/index.test.js
@@ -39,17 +39,31 @@ describe('oval', function () {
     expect(document.body.children.length).to.eq(1)
   })
 
-  it('appendAt', function () {
+  it('appendAt - tag name', function () {
     var el = document.createElement('div')
     document.body.appendChild(el)
     var tag = oval.appendAt(el, 'custom-tag')
     expect(tag).to.exist
   })
 
-  it('mountAt', function () {
+  it('appendAt - tag class', function () {
+    var el = document.createElement('div')
+    document.body.appendChild(el)
+    var tag = oval.appendAt(el, Tag)
+    expect(tag).to.exist
+  })
+
+  it('mountAt - tag name', function () {
     var el = document.createElement('div')
     document.body.appendChild(el)
     var tag = oval.mountAt(el, 'custom-tag')
+    expect(tag).to.exist
+  })
+
+  it('mountAt - tag class', function () {
+    var el = document.createElement('div')
+    document.body.appendChild(el)
+    var tag = oval.mountAt(el, Tag)
     expect(tag).to.exist
   })
 })


### PR DESCRIPTION
# Oval update - add support for Tag class rendering

This PR brings the functionality to use Oval tags as variables, without the need to register them to Oval (with `oval.registerTag`). This brings the functionality to use Oval tags as:

```
var CustomTag = require('custom-tag.tag')
...
<div>
  <CustomTag prop-propa={something} />
</div>
```

it also allows to mount/append tags directly using `oval.appendAt` and `oval.mountAt`

```
var CustomTag = require('custom-tag.tag')

oval.mountAt(document.body, CustomTag)
// or
oval.appendAt(document.body, CustomTag)
```

# Oval compiler update - tag flags and the `local-tag` flag

The compiler now not only gets the `tagName` and `tagAttributes`, but it also parses the so called `tagFlags`. `tagFlags` are attributes without value, hence the name `flags` as they either exist or not.

## Example of tags usage

```
<tag-name attr1="a" attr2="b" flag1 super-flag2 FLAG_THREE>
...
</tag-name>
```

The flags extracted from this tag fingerprint are:

```
['flag1', 'super-flag2', 'FLAG_THREE']
``` 

## The `local-tag` flag

The first usage of flags is the `local-tag` flag. When this flag exists, the compiler will not add `oval.registerTag('tag-name', TagClass)` to the compiled tag code.

## Tests

Tests were added for the parsing of `tagName`, `tagAttributes` and `tagFlags` + for the special `local-tag`

# Other Changes

## Update tests and dependencies

Mocha and jsdom usage is updated to have the latest version of both and no vulnerabilities. Updated the `env.js` file to properly set the `window` and `document` variables globally, so tests should not change.

## Updated `incremental-create-element`

The `createElement` method in oval was updated in order to check if the tag to render is `function`. If it is - it assumes that the element is `Tag` class, gets the name and uses the class instead of `oval.getRegisteredTag`

## Updated oval compilator

In order to not have breaking changes, all of the tags are still registered to `oval` and `tagName` is also attached to each `Tag`'s prototype. There should not be breaking changes.

## Updated oval export

Added the option to have `oval` as a singleton globally in `window`. This is needed sometimes when tags are loaded asynchronously from different js bundles. Using this method will allow to load all tags to the single oval instance, no matter if they `require` it directly from the same bundle or not.