### PR TITLE
Register tag multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## *[4.3.1]* - 2018-08-31
+
+### Added
+
+- `window.ovalRegisterMultiple` - for registering the same tag name multiple times
+
 ## *[4.3.0]* - 2018-08-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ In case there are more than one `js` bundles, all using `organic-oval` we can se
 
 This is helpful when we dynamically require components, but want all of them registered in the same oval instance.
 
+### window.ovalRegisterMultiple
+
+In case we load component from more than one `js` bundles and different bundles contain the same tag, we can set `window.ovalRegisterMultiple` to `true`, which will ignore the second and later requests for registering a tag with a name, that has already been registered.
+
 ### oval.init(plasma)
 
 initializes `organic-oval` with *optional* plasma instance

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var ovalInstance = {
     return instance
   },
   registerTag: function (tagName, TagClass) {
-    if (this.getRegisteredTag(tagName))  {
+    if (this.getRegisteredTag(tagName)) {
       if (!window.ovalRegisterMultiple) throw new Error(tagName + ' already registered')
       else return this.getRegisteredTag(tagName)
     }

--- a/index.js
+++ b/index.js
@@ -65,7 +65,10 @@ var ovalInstance = {
     return instance
   },
   registerTag: function (tagName, TagClass) {
-    if (this.getRegisteredTag(tagName)) throw new Error(tagName + ' already registered')
+    if (this.getRegisteredTag(tagName))  {
+      if (!window.ovalRegisterMultiple) throw new Error(tagName + ' already registered')
+      else return this.getRegisteredTag(tagName)
+    }
     this.registeredTags.push({
       tagName: tagName.toLowerCase(),
       Tag: TagClass

--- a/tests/oval/index.test.js
+++ b/tests/oval/index.test.js
@@ -27,6 +27,16 @@ describe('oval', function () {
     expect(oval.registeredTags.length).to.eq(1)
   })
 
+  it('registerTag - no ovalRegisterMultiple', function () {
+    expect(() => oval.registerTag('custom-tag', Tag)).to.throw
+  })
+
+  it('registerTag - with ovalRegisterMultiple', function () {
+    window.ovalRegisterMultiple = true
+    expect(() => oval.registerTag('custom-tag', Tag)).not.to.throw
+    window.ovalRegisterMultiple = false
+  })
+
   it('getRegisteredTag', function () {
     var Tag = oval.getRegisteredTag('custom-tag')
     expect(Tag).to.eq(Tag)


### PR DESCRIPTION
# Register same tag name multiple times

Sometimes there is a need to register the same tag name multiple times (and automatically ignore the second and later registrations of a tag-name). For this reason, a new `window.ovalRegisterMultiple` option was introduced, which allows same tag name to be registered more than once.

## Usage

```
window.ovalRegisterMultiple = true

oval.registerTag('something', somethingTag)

// ... later

oval.registerTag('something', somethingTag) // does not throw 'something already registered'
```