### PR TITLE
Update dependency - incremental-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/camplight/organic-oval#readme",
   "dependencies": {
-    "incremental-dom": "^0.4.1"
+    "incremental-dom": "^0.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
We are currently using incremental DOM `v0.4.0` as our dependency. There are some bugs in incremental DOM, which have been fixed and an update to the latest `v0.6.0` version would resolve some of the issues in oval.

One of the issues, that made me make this update is this one: https://github.com/google/incremental-dom/issues/237 . In summary - an input loses focus if an element that appears before it in the DOM tree is removed. Even `cid`s are ignored in this case.